### PR TITLE
ユーザー詳細ページにいいねした投稿を見れるように

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,4 +1,5 @@
 class LikesController < ApplicationController
+
   def create
     @post = Post.find(params[:post_id])
     like = current_user.likes.build(post_id: params[:post_id])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,16 @@
 class UsersController < ApplicationController
-  def show
-    @user = User.find(params[:id])
+
+  before_action :authenticate_user!
+
+  def index
+    @users = User.all
   end
+
+  def show
+    @user = User.find_by(id: params[:id])
+    @likes = Like.where(user_id: @user.id)
+  end
+
 
   def follow
     @user = User.find(params[:user_id])

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,6 +3,7 @@ class Post < ApplicationRecord
   belongs_to :user
 
   has_many :likes, dependent: :destroy
+  
   def like_user(user_id)
     likes.find_by(user_id: user_id)
   end
@@ -25,4 +26,9 @@ class Post < ApplicationRecord
       Post.all
     end
   end
+
+  def liked_by?(current_user)
+       likes.where(user_id: current_user.id).exists?
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
 
   has_many :posts, dependent: :destroy
   has_many :likes, dependent: :destroy
+  has_many :like_posts, through: :likes, source: :post
   has_many :comments, dependent: :destroy
 
   acts_as_followable

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,29 +1,32 @@
 <div class="row row-cols md-3">
 <div class="card d-flex justify-content-around m-5" style="width: auto; heigth: auto;">
   <div class="card-body">
+
   
-    <%= image_tag post.image, :width => '280', :height => '280'if post.image.attached? %> 
-    
+  <img src=<%= post.user.image  %> class = "icon_image">
+  
       <h4 class="card-title"><%= post.title %></h4>
       １位<p class="card-text"><%= post.rank1 %></p>
       ２位<p class="card-text"><%= post.rank2 %></p>
       ３位<p class="card-text"><%= post.rank3 %></p>
+
+  <%= image_tag post.image, :width => '280', :height => '280'if post.image.attached? %> 
     
-    <div class="btn-group">
+      <p class="card-text">
+        <small class="text-muted"><%= post.updated_at %>
+        </small>
+      </p>
+
+      <% post.tags.each do |tag| %>
+    <span class= 'badge badge-primary'><%= tag.tag_name %></span>
+    <% end %>
+
+      <div class="btn-group">
       <button type="button" class="btn btn-sm btn-outline-secondary">
         <%= link_to '詳細', post_path(post.id) , method: :get %></button>
       <button type="button" class="btn btn-sm btn-outline-secondary">
         <%=link_to post.user.name, user_path(post.user.id)%></button>
     </div>
-
-    <% post.tags.each do |tag| %>
-    <span class= 'badge badge-primary'><%= tag.tag_name %></span>
-    <% end %>
-
-      <p class="card-text">
-        <small class="text-muted"><%= post.updated_at %>
-        </small>
-      </p>
 
       <div id="likes_buttons_<%= post.id %>">
       <%= render partial: 'likes/like', locals: { post: post} %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,3 @@
-
 <div class="jumbotron jumbotron-fluid">
   <div class="container">
 
@@ -24,6 +23,7 @@
     <%= link_to "フォロー", {controller: :users,action: :follow_list,user_id: @user.id}, method: :get %>
     <%= @user.followers_count %>
     <%= link_to "フォロワー", {controller: :users,action: :follower_list,user_id: @user.id}, method: :get %>
+    
 
   </div>
 </div>
@@ -33,11 +33,72 @@
 </button>
 
 
-
+<h3 class="mt-3">投稿一覧</h3>
 
 <div class="row row-cols md-3">
 
-<%= render partial: 'posts/post', collection: @user.posts.order("created_at DESC") %>
+  <%= render partial: 'posts/post', collection: @user.posts.order("created_at DESC") %>
+
+</div>
+
+<h3 class="mt-3">いいね一覧</h3>
+
+<div class="row row-cols md-3">
+
+<% @likes.each do |like| %>
+    <% post = Post.find_by(id: like.post_id) %>
+    <% user = User.find_by(id: post.user_id) %>
+
+    <div class="card d-flex justify-content-around m-5" style="width: auto; heigth: auto;">
+  <div class="card-body border border-primary">
+  
+  <img src=<%= post.user.image %>  class = "icon_image">
+    
+    
+      <h4 class="card-title"><%= post.title %></h4>
+      １位<p class="card-text"><%= post.rank1 %></p>
+      ２位<p class="card-text"><%= post.rank2 %></p>
+      ３位<p class="card-text"><%= post.rank3 %></p>
+
+      <%= image_tag post.image, :width => '280', :height => '280'  if post.image.attached? %>
+
+             
+    
+<p>
+    <div class="btn-group">
+          <button type="button" class="btn btn-5m btn-outline-secondary">
+            <%= link_to '詳細', post_path(post.id) , method: :get %></button>
+          <button type="button" class="btn btn-5m btn-outline-secondary">
+            <%=link_to post.user.name, user_path(post.user.id)%></button>
+    </div>
+</p>
+
+<p>
+    <div id="likes_buttons_<%= post.id %>">
+      <%= render partial: 'likes/like', locals: { post: post} %>
+    </div>
+</p>
+
+
+    
+      <p class="card-text">
+        <small class="text-muted"><%= post.updated_at %>
+        </small>
+      </p>
+
+       <% post.tags.each do |tag| %>
+        <span class= 'badge badge-primary'>
+        <%= tag.tag_name %>
+        </span>
+      <% end %>
+
+
+  </div>
+  </div>
+<% end %>
+
+</div>
+
 
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,8 @@ Rails.application.routes.draw do
   devise_for :users, controllers: { registrations: 'users/registrations' }
   root to: 'posts#index'
 
-  resources :users, only: [:show]
+  resources :users, only: [:index, :show] 
+
 
   resources :posts do
     resources :comments, only: :create
@@ -11,6 +12,9 @@ Rails.application.routes.draw do
       get 'search'
     end
   end
+
+  get "users/:id/likes"=>"users#likes"
+  get "posts/:id/likes" => "posts#likes"
 
   put 'users/follow/:user_id' => 'users#follow'
   put 'users/unfollow/:user_id' => 'users#unfollow'
@@ -24,4 +28,5 @@ Rails.application.routes.draw do
   get 'users/follow_list/:user_id' => 'users#follow_list'
   get 'users/follower_list/:user_id' => 'users#follower_list'
  
+  
 end


### PR DESCRIPTION
WHAT　
ユーザーページでいいねした投稿を閲覧出来る機能

WHY
せっかくいいね、と思ってボタンを押してくれたのに
マークと数字が変わるだけだったので、いいねした投稿をその後閲覧することによって
ユーザー間でコミュニケーションを取れる機会を増やし、思い出として見返すことも出来るようにした